### PR TITLE
Fix stochastic test failure in Day 6 Part 2

### DIFF
--- a/src/bin/06.rs
+++ b/src/bin/06.rs
@@ -117,6 +117,7 @@ pub fn part_two(input: &str) -> Option<S> {
     let mut loop_count: S = 0;
 
     for obs in locs {
+        guard.reset();
         guard.obstacles.insert(obs);
         guard.solve();
 
@@ -124,7 +125,6 @@ pub fn part_two(input: &str) -> Option<S> {
             loop_count += 1
         }
 
-        guard.reset();
         guard.obstacles.remove(&obs);
     }
 


### PR DESCRIPTION
## Summary
Fixes the intermittent test failure in Day 6 Part 2 by ensuring the guard state is properly reset before each obstacle test.

## Problem
The test was failing approximately 10% of the time due to non-deterministic iteration order over a HashSet combined with improper state management.

## Solution
Moved `guard.reset()` to the beginning of the obstacle testing loop. This ensures:
- Each obstacle test starts with a clean guard state
- Results are consistent regardless of HashSet iteration order
- No state contamination between iterations

## Testing
- Before fix: Test failed ~1 in 10 runs
- After fix: Test passed 20 consecutive runs
- Solution still produces correct output.

Fixes #30